### PR TITLE
solving axis bug and adding xbox controlers and a simple qs_profile

### DIFF
--- a/joystick_ros2.py
+++ b/joystick_ros2.py
@@ -153,7 +153,7 @@ XONE_VALUE_MAP = {
     1: (-32768, 32767),
     2: (0, 1023),
     3: (-32768, 32767),
-    4: (-32768, -32767),
+    4: (-32768, 32767),
     5: (0, 1023),
     6: (-1, 1),
     7: (-1, 1)
@@ -163,7 +163,9 @@ JOYSTICK_CODE_VALUE_MAP = {
     'Microsoft X-Box 360 pad': (XINPUT_CODE_MAP, XINPUT_VALUE_MAP),
     'Sony Computer Entertainment Wireless Controller': (PS4_CODE_MAP, PS4_VALUE_MAP),
     'Logitech Gamepad F710': (F710_CODE_MAP, F710_VALUE_MAP),
-    'Microsoft X-Box One pad': (XONE_CODE_MAP, XONE_VALUE_MAP)
+    'Microsoft X-Box One pad': (XONE_CODE_MAP, XONE_VALUE_MAP),
+    'Microsoft X-Box One S pad': (XONE_CODE_MAP, XONE_VALUE_MAP),
+    'Generic X-Box pad': (XONE_CODE_MAP, XONE_VALUE_MAP)
 }
 
 class JoystickRos2(Node):
@@ -186,7 +188,7 @@ class JoystickRos2(Node):
         self.joy.buttons = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
         # Joy publisher
-        self.publisher_ = self.create_publisher(Joy, 'joy')
+        self.publisher_ = self.create_publisher(Joy, 'joy', 10)
 
         # logic params
         self.last_event = None


### PR DESCRIPTION
In the joystick_ros2.py file, in line 156 both axes are negative, so I also changed the new controls it's just copies generics of Xbox controllers and other versions like the S, the simple qs_profile its only a parameter 10 for ros2